### PR TITLE
You can pass key as second parameter in the each callback on xml files

### DIFF
--- a/src/Parsers/XMLParser.php
+++ b/src/Parsers/XMLParser.php
@@ -46,7 +46,7 @@ class XMLParser implements StreamParserInterface
 	private function searchElement(callable $function)
 	{
 		if($this->isElement() && ! $this->shouldBeSkipped()){
-			$function($this->extractElement($this->reader->name, false, $this->reader->depth));
+			$function($this->extractElement($this->reader->name, false, $this->reader->depth), $this->reader->name);
 		}
 	}
 
@@ -137,11 +137,11 @@ class XMLParser implements StreamParserInterface
 		return $this->reader->nodeType == XMLReader::TEXT || $this->reader->nodeType === XMLReader::CDATA;
 	}
 
-    private function isEmptyElement(String $elementName = null){
-	    if($elementName) {
-		    return $this->reader->isEmptyElement && $this->reader->name === $elementName;
-	    } else {
-		    return false;
-	    }
-    }
+	private function isEmptyElement(String $elementName = null){
+		if($elementName) {
+			return $this->reader->isEmptyElement && $this->reader->name === $elementName;
+		} else {
+			return false;
+		}
+	}
 }

--- a/tests/Parsers/XMLParserTest.php
+++ b/tests/Parsers/XMLParserTest.php
@@ -92,20 +92,26 @@ class XMLParserTest extends TestCase implements ElementAttributesManagement, Ele
 		$this->assertEquals($totalComments, $countedComments);
 	}
 
-    public function test_element_is_empty()
-    {
-	    StreamParser::xml($this->stub)->each(function($book) {
-		    if($book->has('reviews')) {
-			    $this->assertEmpty($book->get('reviews'));
-		    }
-	    });
+	public function test_element_is_empty()
+	{
+		StreamParser::xml($this->stub)->each(function($book) {
+			if($book->has('reviews')) {
+				$this->assertEmpty($book->get('reviews'));
+			}
+		});
 	}
 
-	public function test_it_parses_child_with_same_parent_name(){
+	public function test_it_parses_child_with_same_parent_name() {
 		StreamParser::xml($this->stub)->each(function($book){
 			if($book->has('book')){
 				$this->assertEquals($book->get('book'), "The nested element named like the parent");
 			}
+		});
+	}
+
+	public function test_pass_key_element_in_callback() {
+		StreamParser::xml($this->stub)->each(function($book, $key){
+			$this->assertEquals($key, 'book');
 		});
 	}
 }


### PR DESCRIPTION
The idea is being able to pass a `$key` parameter on the `->each` callback, just like regular `Collection()->each` function works.

This is really useful when you are parsing ONIX files (talking about books), where its useful to know the parent tag we are working on.

Example:
```XML
<ONIXMessage release="3.0">
  <Header>
    ...
  </Header>
  <Product>
    ...
  </Product>
  <Product>
    ...
  </Product>
</ONIXMessage>
```

Usecase:
```php
StreamParser::xml("https://example.com/onix.xml")->each(function($data, $key){
    dump($key)
});
```

Output:
```
Header
Product
Product
```