### PR TITLE
Update XMLParser.php

### DIFF
--- a/src/Parsers/XMLParser.php
+++ b/src/Parsers/XMLParser.php
@@ -52,9 +52,11 @@ class XMLParser implements StreamParserInterface
 
 	private function extractElement(String $elementName, $couldBeAnElementsList = false, int $parentDepth)
 	{
+		$emptyElement = $this->isEmptyElement($elementName);
+		
 		$elementCollection = (new Collection())->merge($this->getCurrentElementAttributes());
 
-		if($this->isEmptyElement($elementName)) {
+		if($emptyElement) {
 			return $elementCollection;
 		}
 


### PR DESCRIPTION
Take care about how to use XMLReader::$isElementEmpty. I don't know if it is a bug or not, but $isElementEmpty is set for the current context and not just for the element. If you move your cursor to an attribute, $isElementEmpty will always be false.
```

<?php
$xml = new XMLReader();
$xml->XML('<tag attr="value" />');
$xml->read();
var_dump($xml->isEmptyElement);
$xml->moveToNextAttribute();
var_dump($xml->isEmptyElement);
?>
```

will output

(bool) true
(bool) false

So be sure to store $isEmptyElement before moving the cursor.
