### PR TITLE
tightenco/collect replaced with illuminate/collections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
   "require": {
     "php": ">=7.1",
     "ext-xmlreader": "*",
-    "maxakawizard/json-collection-parser": "^1.1",
-    "tightenco/collect": "^5.0|^6.0|^7.0|^8.0"
+    "illuminate/collections": "^8.0|^9.0",
+    "maxakawizard/json-collection-parser": "^1.1"
   },
 
   "require-dev": {
     "mockery/mockery": "^0.9.9",
-    "phpunit/phpunit": "^6.0"
+    "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0"
   },
 
   "autoload": {

--- a/src/Parsers/CSVParser.php
+++ b/src/Parsers/CSVParser.php
@@ -9,9 +9,9 @@
 namespace Rodenastyle\StreamParser\Parsers;
 
 
+use Illuminate\Support\Collection;
 use Rodenastyle\StreamParser\Exceptions\IncompleteParseException;
 use Rodenastyle\StreamParser\StreamParserInterface;
-use Tightenco\Collect\Support\Collection;
 
 class CSVParser implements StreamParserInterface
 {
@@ -100,7 +100,7 @@ class CSVParser implements StreamParserInterface
 	private function explodeCollectionValues(Collection $collection){
 		$collection->transform(function($value){
 			(new Collection(static::$delimiters))->each(function($delimiter) use (&$value){
-				if( ! is_array($value) && strpos($value, $delimiter) !== false){
+				if( ! is_array($value) && $value !== null && strpos($value, $delimiter) !== false){
 					$value = explode($delimiter, $value);
 				}
 			});

--- a/src/Parsers/JSONParser.php
+++ b/src/Parsers/JSONParser.php
@@ -9,9 +9,9 @@
 namespace Rodenastyle\StreamParser\Parsers;
 
 
+use Illuminate\Support\Collection;
 use Rodenastyle\StreamParser\Services\JsonCollectionParser as Parser;
 use Rodenastyle\StreamParser\StreamParserInterface;
-use Tightenco\Collect\Support\Collection;
 
 class JSONParser implements StreamParserInterface
 {

--- a/src/Parsers/XMLParser.php
+++ b/src/Parsers/XMLParser.php
@@ -9,9 +9,9 @@
 namespace Rodenastyle\StreamParser\Parsers;
 
 
+use Illuminate\Support\Collection;
 use Rodenastyle\StreamParser\Exceptions\IncompleteParseException;
 use Rodenastyle\StreamParser\StreamParserInterface;
-use Tightenco\Collect\Support\Collection;
 use XMLReader;
 
 
@@ -57,7 +57,7 @@ class XMLParser implements StreamParserInterface
 		}
 	}
 
-	private function extractElement(String $elementName, $couldBeAnElementsList = false, int $parentDepth, string $foundInEl = null)
+	private function extractElement(String $elementName, bool $couldBeAnElementsList, int $parentDepth, string $foundInEl = null)
 	{
 		$emptyElement = $this->isEmptyElement($elementName);
 		

--- a/src/StreamParser.php
+++ b/src/StreamParser.php
@@ -9,11 +9,11 @@
 namespace Rodenastyle\StreamParser;
 
 
+use Illuminate\Support\Collection;
 use Rodenastyle\StreamParser\Parsers\CSVParser;
 use Rodenastyle\StreamParser\Parsers\JSONParser;
 use Rodenastyle\StreamParser\Parsers\XMLParser;
 use Rodenastyle\StreamParser\Traits\Facade;
-use Tightenco\Collect\Support\Collection;
 
 class StreamParser
 {

--- a/tests/Parsers/CSVParserTest.php
+++ b/tests/Parsers/CSVParserTest.php
@@ -8,10 +8,10 @@
 
 namespace Rodenastyle\StreamParser\Test\Parsers;
 
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 use Rodenastyle\StreamParser\StreamParser;
 use Rodenastyle\StreamParser\Parsers\CSVParser;
-use Tightenco\Collect\Support\Collection;
 
 class CSVParserTest extends TestCase
 {

--- a/tests/Parsers/JSONParserTest.php
+++ b/tests/Parsers/JSONParserTest.php
@@ -8,9 +8,9 @@
 
 namespace Rodenastyle\StreamParser\Test\Parsers;
 
+use Illuminate\Support\Collection;
 use Rodenastyle\StreamParser\Test\TestCase;
 use Rodenastyle\StreamParser\StreamParser;
-use Tightenco\Collect\Support\Collection;
 
 class JSONParserTest extends TestCase
 {

--- a/tests/Parsers/TSVParserTest.php
+++ b/tests/Parsers/TSVParserTest.php
@@ -8,21 +8,21 @@
 
 namespace Rodenastyle\StreamParser\Test\Parsers;
 
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 use Rodenastyle\StreamParser\StreamParser;
 use Rodenastyle\StreamParser\Parsers\CSVParser;
-use Tightenco\Collect\Support\Collection;
 
 class TSVParserTest extends TestCase
 {
 	private $stub = __DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."Stubs".DIRECTORY_SEPARATOR."sample.tsv";
 
-	protected function setUp() {
+	protected function setUp(): void {
 		CSVParser::$fieldDelimiter = "\t";
 		CSVParser::$skipsEmptyLines = true;
 	}
 
-	protected function tearDown()
+	protected function tearDown(): void
 	{
 		CSVParser::$fieldDelimiter = ",";
 	}

--- a/tests/Parsers/XMLParserTest.php
+++ b/tests/Parsers/XMLParserTest.php
@@ -8,12 +8,12 @@
 
 namespace Rodenastyle\StreamParser\Test\Parsers;
 
+use Illuminate\Support\Collection;
 use Rodenastyle\StreamParser\StreamParser;
 use Rodenastyle\StreamParser\Test\Contracts\ElementAttributesManagement;
 use Rodenastyle\StreamParser\Test\Contracts\ElementListManagement;
 use Rodenastyle\StreamParser\Test\Contracts\ElementDepthManagement;
 use Rodenastyle\StreamParser\Test\TestCase;
-use Tightenco\Collect\Support\Collection;
 
 class XMLParserTest extends TestCase implements ElementAttributesManagement, ElementListManagement, ElementDepthManagement {
 


### PR DESCRIPTION
This package is deprecated: https://github.com/tighten/collect.

Added compatibility with new phpunit for new php versions such as 8.*